### PR TITLE
Return expected http status code

### DIFF
--- a/sanic_restful_api/representations/json.py
+++ b/sanic_restful_api/representations/json.py
@@ -9,7 +9,7 @@ def output_json(app, data, code, headers=None):
     dumped = dumps(data, **settings) + "\n"
     resp = HTTPResponse(
         dumped,
-        status=200,
+        status=code,
         content_type="application/json",
     )
     resp.headers.extend(headers or {})


### PR DESCRIPTION
In the output_json, the HTTPResponse should take the "code" arg as http status code instead of the generic 200 code.